### PR TITLE
Pelis final dropdown

### DIFF
--- a/nodes/ui_dropdown.html
+++ b/nodes/ui_dropdown.html
@@ -20,7 +20,7 @@
             payload: {value: ''},
             topic: {value: ''}
         },
-        inputs:0,
+        inputs:1,
         outputs:1,
         icon: "ui_dropdown.png",
         paletteLabel: 'dropdown',

--- a/nodes/ui_dropdown.js
+++ b/nodes/ui_dropdown.js
@@ -10,11 +10,7 @@ module.exports = function(RED) {
         var tab = RED.nodes.getNode(group.config.tab);
         if (!tab) { return; }
 
-        var done = ui.add({
-            node: node,
-            tab: tab,
-            group: group,
-            control: {
+        var control = {
                 type: 'dropdown',
                 label: config.label,
                 order: config.order,
@@ -22,11 +18,70 @@ module.exports = function(RED) {
                 width: config.width || group.config.width || 6,
                 height: config.height || 1,
                 options: config.options
+            };
+
+        var done = ui.add({
+            node: node,
+            tab: tab,
+            group: group,
+            control: control,
+            
+            beforeEmit: function (msg, newValue) {
+                // as of now, only allow a full replacement of options
+                // beforeEmit is only called when an node linked to us send a msg
+                // we are expecting to receive an "update options" msg 
+                // which we expect to be an array of new options
+
+                // for convenience, we pass an indication to the node connected to this dropdown
+                // that this is an "update options" message coming from the input sender
+                // 'beforeEmit' is called before 'beforeSend', so we may pass in that info
+                // otherwise that convenience info would not be sent (would not cause any problems)...
+                msg.isOptionUpdate = true;
+                msg.isOptionsValid = false; // initial value
+
+                if (!Array.isArray(msg.payload)) return {isOptionsValid: false, value: undefined, newOptions : undefined};
+
+                // an empty array will remove all items from the dropdown 
+                if (msg.payload.length === 0) {
+                    msg.isOptionsValid = true;
+                    control.options = [];
+                    return {isOptionsValid: true, value: undefined, newOptions : []};
+                }
+
+                // just doing rudimentary checks on the input payload...
+                if (msg.payload[0].hasOwnProperty("label") && msg.payload[0].hasOwnProperty("value")) { 
+                    // we expect all objects to contain 'label' and 'value' members
+                    for (i = 0; i < msg.payload.length; i++) {
+                        if (! (msg.payload[i].hasOwnProperty("label") && msg.payload[i].hasOwnProperty("value")) ) break;
+                    }
+                    isOptionsValid = (i === msg.payload.length);
+                } else {
+                    var newOpts = [];
+                    // we just assume a value array, so we create label / value pairs
+                    for (i = 0; i < msg.payload.length; i++) {
+                        if ( typeof(msg.payload[i]) === 'object' ) break; // invalid
+                        newOpts.push({label: msg.payload[i], value: msg.payload[i]});
+                    }
+                    isOptionsValid = (i === msg.payload.length);
+                    msg.payload = newOpts;
+                }
+
+                // the sending node may pass item to be selected from the new options list
+                // if selectItem does not exist in the options list, dropdown will not select anything
+                if (isOptionsValid) {
+                    value = (msg.selectItem ? msg.selectItem : msg.payload[0].value);
+                    control.options = msg.payload;
+                }
+    
+                msg.isOptionsValid = isOptionsValid;
+                return {isOptionsValid: isOptionsValid, value: value, newOptions: isOptionsValid ? msg.payload : undefined};
             },
+            
             beforeSend: function (msg) {
                 msg.topic = config.topic;
             }
         });
+
         node.on("close", done);
     }
     RED.nodes.registerType("ui_dropdown", DropdownNode);

--- a/src/components/ui-component/ui-component-ctrl.js
+++ b/src/components/ui-component/ui-component-ctrl.js
@@ -29,6 +29,15 @@ angular.module('ui').controller('uiComponentController', ['$scope', 'UiEvents', 
                     me.itemChanged = function () {
                         me.valueChanged(0);
                     };
+
+                    // PL dropdown
+                    // add 'me' to item and register processInput
+                    // this is called from main.js
+                    me.item.me = me;
+                    me.processInput = function (msg) {
+                        processDropDownInput(msg);
+                    }
+
                     break;
                 }
 
@@ -112,4 +121,16 @@ angular.module('ui').controller('uiComponentController', ['$scope', 'UiEvents', 
                 events.emit(data);
             }, timeout);
         };
+
+        // may add additional input processing for other controls
+        var processDropDownInput = function (msg) {
+           // options should have the correct format see beforeEmit in ui-dropdown.js
+            if (msg && msg.isOptionsValid) {
+                me.item.options = msg.newOptions;
+                // delete items passed to me (may as well just keep them)
+                delete me.item.isOptionsValid;
+                delete me.item.newOptions;
+            }
+        };
+       
     }]);

--- a/src/main.js
+++ b/src/main.js
@@ -85,6 +85,11 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
                     found[key] = msg[key];
                 }
             }
+            
+            // PL
+            if (found.hasOwnProperty("me") && found.me.hasOwnProperty("processInput")) {
+                found.me.processInput(msg);
+            }
         });
 
         events.on('show-toast', function (msg) {


### PR DESCRIPTION
Hope this is now the proper way...
The way it should work:
dropdown may now receive an input message which contains:
- an array of new option entries
  in this case beforeEmit () will transform the option list to an array of Objects: [{label: "l1", value: "v1"}, ...]
- an array of label/value objects
I am also setting such new values in the control (back-end) so that a 'replay' will reflect such new entries

Attached is a sample flow to test things...
[red-dashboard-dropdown.txt](https://github.com/node-red/node-red-dashboard/files/407120/red-dashboard-dropdown.txt)

In the end it turned out to be somewhat tricky...