### PR TITLE
Added ability to not forward button messages

### DIFF
--- a/nodes/ui_button.html
+++ b/nodes/ui_button.html
@@ -15,6 +15,7 @@
                     return valid;
                 }
             },
+            passthru: {value: true},
             height: {value: 0},
             label: {value: 'button'},
             color: {value: ''},
@@ -70,6 +71,10 @@
     <div class="form-row">
         <label for="node-input-bgcolor"><i class="fa fa-tint"></i>  Background</label>
         <input type="text" id="node-input-bgcolor" placeholder="optional background color">
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
     <div class="form-row">
         <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When clicked, send:</label>

--- a/nodes/ui_button.js
+++ b/nodes/ui_button.js
@@ -33,6 +33,7 @@ module.exports = function(RED) {
             node: node,
             tab: tab,
             group: group,
+            forwardInputMessages: config.passthru,
             control: {
                 type: 'button',
                 label: config.label,


### PR DESCRIPTION
This PR is intended to simplify flows that update the "enabled" (or other UI state) of a button, whilst also relying on a event actions.

Button messages with object type inputs get incorrectly passed on as string "[Object object]" outputs.

This PR adds the ability, as used in other controls, to not pass on an input message to outputs. This is a workaround for the above, potential, bug and adds additional user flexibility.

The passthrough mode defaults to enabled - as per current behavior.