### PR TITLE
add IOS homescreen icon link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,10 @@
     <link rel="icon" sizes="192x192" href="icon.jpg">
     <link rel="shortcut icon" type="image/png" href="icon.png">
 
+    <!-- apple touch icon -->
+    <link rel="apple-touch-icon" href="icon.png">
+    <meta name="apple-mobile-web-app-title" content="Node-RED">
+
     <!-- build:css -->
     <link rel="stylesheet" href="vendor/angular-material/angular-material.min.css">
     <link rel="stylesheet" href="vendor/angular-material-icons/angular-material-icons.css">


### PR DESCRIPTION
This adds support for IOS homescreen icon which allows you to save the Node-RED dashboard as an IOS app icon. The benefit of this is that the dashboard will run in fullscreen mode.