### PR TITLE
Fix icon positioning on mini fab buttons.

### DIFF
--- a/src/theme.less
+++ b/src/theme.less
@@ -209,11 +209,15 @@ md-select-menu md-option:focus:not([disabled]):not([selected]) {
 .nr-dashboard-theme .nr-dashboard-template .md-button {
 	background: @widgetBackgroundColor;
 	color: white;
-    margin: 0px 6px;
-    padding: 0px 12px;
-    min-height: 26px;
-    min-width: unset;
-    line-height: unset;
+	margin: 0px 6px;
+	padding: 0px 12px;
+	min-height: 26px;
+	min-width: unset;
+	line-height: unset;
+	
+	&.md-fab.md-mini {
+		padding: 0px 6px;
+	}
 }
 
 .nr-dashboard-theme .nr-dashboard-template .md-button:hover {

--- a/src/theme.less
+++ b/src/theme.less
@@ -216,7 +216,7 @@ md-select-menu md-option:focus:not([disabled]):not([selected]) {
 	line-height: unset;
 	
 	&.md-fab.md-mini {
-		padding: 0px 6px;
+		padding: unset;
 	}
 }
 


### PR DESCRIPTION
With `padding: 0px 12px;` in `.nr-dashboard-theme .nr-dashboard-template .md-button` it pushes contents inside `.md-fab.md-mini` to the right, fallback to original style.