### PR TITLE
ui_switch: add flag to match input topic

### DIFF
--- a/nodes/ui_switch.html
+++ b/nodes/ui_switch.html
@@ -18,6 +18,7 @@
             },
             height: {value: 0},
             passthru: {value: true},
+            matchtopic: {value: false},
             decouple: {value: "false"},
             topic: {value: ''},
             style: {value: ''},
@@ -125,6 +126,9 @@
     <div class="form-row">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+            <br/>
+        <label style="width:auto" for="node-input-matchtopic"><i class="fa fa-arrow-right"></i> Accept input <code>msg</code> only if its <code>msg.topic</code> matches: </label>
+        <input type="checkbox" id="node-input-matchtopic" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
     <div class="form-row form-row-decouple">
         <label for="node-input-decouple"><i class="fa fa-toggle-on"></i> Indicator</label>

--- a/nodes/ui_switch.js
+++ b/nodes/ui_switch.js
@@ -75,7 +75,8 @@ module.exports = function(RED) {
                 width: config.width || group.config.width || 6,
                 height: config.height || 1
             },
-            convert: function (payload, oldval) {
+            convert: function (payload, oldval, msg) {
+                if (config.matchtopic && msg.topic !== config.topic) { return oldval; }
                 var myOnValue,myOffValue;
 
                 if (onvalueType === "date") { myOnValue = Date.now(); }


### PR DESCRIPTION
By default input message act on the control state with no respect to message topic.

I propose to add a flag (default is false) that controls whether the state of the control is changed only if input message topic matches `config.topic`.
That way one could get rid of unnecessary branching by message topic before a set of switches.

Please, consider applying
