### PR TITLE
Make dashboard work without LocalStorage

### DIFF
--- a/src/components/ui-card-panel/ui-card-panel.js
+++ b/src/components/ui-card-panel/ui-card-panel.js
@@ -9,13 +9,13 @@ angular.module('ui').directive('uiCardPanel', ['$timeout',
             controller: 'uiCardPanelController',
             controllerAs: 'ctrl',
             link: function (scope, element, attrs, controller) {
-                scope.collapsed = ((localStorage.getItem(attrs.id) || false) == 'true');
+                scope.collapsed = (((localStorage && localStorage.getItem(attrs.id)) || false) == 'true');
                 var root = element.find(".nr-dashboard-cardcontainer");
                 var slideDuration = 0;
                 controller.init(root);
                 scope.collapseCard = function() {
                     scope.collapsed = !scope.collapsed;
-                    localStorage.setItem(attrs.id,scope.collapsed);
+                    if (localStorage) localStorage.setItem(attrs.id,scope.collapsed);
                     root.slideToggle(slideDuration);
                     $timeout(function() { $(window).trigger('resize'); }, slideDuration);
                     slideDuration = parseInt(attrs.slideToggleDuration, 10) || 150;

--- a/src/main.js
+++ b/src/main.js
@@ -154,7 +154,7 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
                     for (var g in main.menu[t].items) {
                         if (main.menu[t].items.hasOwnProperty(g)) {
                             var c = (main.menu[t].header+" "+main.menu[t].items[g].header.name).replace(/ /g,"_");
-                            if (localStorage.getItem(c) == "true") {
+                            if (localStorage && localStorage.getItem(c) == "true") {
                                 main.menu[t].items[g].header.config.hidden = true;
                                 flag = true;
                             }


### PR DESCRIPTION
This is useful:
(1) when user has disabled localstorage
(2) in android captive portal browser, which does not support LocalStorage

Currently, the dashboard is completely broken with LocalStorage disabled/unavailable
(window.localStorage == null)