### PR TITLE
update i18n & JP message catalogue

### DIFF
--- a/nodes/locales/en-US/ui_tab.json
+++ b/nodes/locales/en-US/ui_tab.json
@@ -5,6 +5,7 @@
             "tab" : "Tab",
             "name" : "Name",
             "icon" : "Icon"
-        }
+        },
+	"tip" : "The <b>Icon</b> field can be either a <a href=\"https://design.google.com/icons/\" target=\"_blank\">Material Design icon</a> <i>(e.g. 'check', 'close')</i> or a <a href=\"https://fontawesome.com/v4.7.0/icons/\" target=\"_blank\">Font Awesome icon</a> <i>(e.g. 'fa-fire')</i>, or a <a href=\"https://github.com/Paul-Reed/weather-icons-lite/blob/master/css/weather-icons-lite.css\" target=\"_blank\">Weather icon</a> <i>(e.g. 'wi-wu-sunny')</i>.</p>"
     }
 }

--- a/nodes/locales/ja/ui_group.json
+++ b/nodes/locales/ja/ui_group.json
@@ -8,6 +8,7 @@
             "group" : "グループ",
             "unassigned" : "未設定"
         },
-        "display-name" : "グループ名を表示する"
+        "display-name" : "グループ名を表示する",
+        "collapse-name" : "グループの折りたたみを有効にする"
     }
 }

--- a/nodes/locales/ja/ui_link.json
+++ b/nodes/locales/ja/ui_link.json
@@ -6,6 +6,7 @@
             "icon" : "アイコン",
             "open-in" : "開く方法",
             "new-tab" : "新規タブ",
+            "this-tab" : "このタブ",
             "iframe" : "iframe"
         }
     }

--- a/nodes/locales/ja/ui_tab.json
+++ b/nodes/locales/ja/ui_tab.json
@@ -5,6 +5,7 @@
             "tab" : "タブ",
             "name" : "名前",
             "icon" : "アイコン"
-        }
+        },
+	"tip" : "<b>アイコン</b>フィールドには <a href=\"https://design.google.com/icons/\" target=\"_blank\">Material Design icon</a> <i>(例: 'check', 'close')</i>、<a href=\"https://fontawesome.com/v4.7.0/icons/\" target=\"_blank\">Font Awesome icon</a> <i>(例: 'fa-fire')</i>、もしくは <a href=\"https://github.com/Paul-Reed/weather-icons-lite/blob/master/css/weather-icons-lite.css\" target=\"_blank\">Weather icon</a> <i>(例: 'wi-wu-sunny')</i>を指定できます。</p>"	
     }
 }

--- a/nodes/ui_tab.html
+++ b/nodes/ui_tab.html
@@ -28,11 +28,7 @@
         <label for="node-config-input-icon"><i class="fa fa-file-image-o"></i> <span data-i18n="ui_tab.label.icon"></span></label>
         <input type="text" id="node-config-input-icon">
     </div>
-    <div class="form-tips">The <b>Icon</b> field can be either a
-    <a href="https://design.google.com/icons/" target="_blank">Material Design icon</a> <i>(e.g. 'check', 'close')</i>
-    or a <a href="https://fontawesome.com/v4.7.0/icons/" target="_blank">Font Awesome icon</a> <i>(e.g. 'fa-fire')</i>,
-    or a <a href="https://github.com/Paul-Reed/weather-icons-lite/blob/master/css/weather-icons-lite.css" target="_blank">Weather icon</a> <i>(e.g. 'wi-wu-sunny')</i>.</p>
-    </div>
+    <div class="form-tips" data-i18n="[html]ui_tab.tip"></div>
 </script>
 
 <script type="text/x-red" data-help-name="ui_tab">


### PR DESCRIPTION
Some messages of `ui_group`, `ui_link`, and `ui_tab` are not i18 ready.
Updated them with support of i18n text and Japanese message catalogue.