### PR TITLE
Add support of i18n and Japanese message for ui_template

### DIFF
--- a/nodes/locales/en-US/ui_template.json
+++ b/nodes/locales/en-US/ui_template.json
@@ -1,0 +1,16 @@
+{
+    "ui_template" : {
+	"label" : {
+	    "category" : "dashboard",
+	    "type" : "Template type",
+	    "local" : "Widget in group",
+	    "global" : "Added to site <head> section",
+	    "group" : "Group",
+	    "size" : "Size",
+	    "name" : "Name",
+	    "pass-through" : "Pass through messages from input.",
+	    "store-state" : "Add output messages to stored state.",
+	    "template" : "Template"
+	}
+    }
+}

--- a/nodes/locales/ja/ui_template.html
+++ b/nodes/locales/ja/ui_template.html
@@ -1,0 +1,44 @@
+<script type="text/x-red" data-help-name="ui_template">
+  <p>Template WidgetにはHTMLコードおよびAngular/Angular-Materialディレクティブを指定できます。</p>
+  <p>このノードで動的なユーザインターフェイス要素を作成し、入力によって見た目を変更したり、メッセージをNode-REDに送り返したりできます。</p>
+    <p><b>例:</b><br>
+  <pre style="font-size:smaller;">&lt;div layout=&quot;row&quot; layout-align=&quot;space-between&quot;&gt;
+  &lt;p&gt;数値は&lt;/p&gt;
+  &lt;p ng-style=&quot;{color: (msg.payload || 0) % 2 === 0 ? 'green' : 'red'}&quot;&gt;
+    {{(msg.payload || 0) % 2 === 0 ? '偶数' : '奇数'}}
+  &lt;/p&gt;
+&lt;/div&gt;</pre>
+    このコードは<code>msg.payload</code>で受け取った数値が偶数か奇数かを表示します。同時に、偶数であれば緑に、奇数であれば赤にテキストの色を変更します。<br/>
+    次は、一意なIDをテンプレートに設定、デフォルトのテーマカラーを設定、入力メッセージの到着を監視する例です。</p>
+    <pre style="font-size:smaller;">
+&lt;div id="{{'my_'+$id}}" style="{{'color:'+theme.base_color}}"&gt;何らかのテキスト&lt;/div&gt;
+&lt;script&gt;
+(function(scope) {
+  scope.$watch('msg', function(msg) {
+    if (msg) {
+      // メッセージ同着時に適当な処理を実行
+      $("#my_"+scope.$id).html(msg.payload);
+    }
+  });
+})(scope);
+&lt;/script&gt;</pre>
+    <p>この方法で作成したテンプレートはコピー可能です。コピーはそれぞれ独立して利用できます。</p>
+    <p><b>メッセージ送信:</b><br>
+    <pre style="font-size:smaller;">
+&lt;script&gt;
+var value = "こんにちは世界";
+// もしくは、コールバック関数で値を書き換え
+this.scope.action = function() { return value; }
+&lt;/script&gt;
+&lt;md-button ng-click=&quot;send({payload:action()})&quot;&gt;
+    クリックすると「こんにちは世界」を送信します
+&lt;/md-button&gt;</pre>
+    この例は、クリックするとペイロードに<code>'こんにちは世界'</code>を持つメッセージを送信するボタンを表示します。</p>
+  <p><b><code>msg.template</code>の使用:</b><br>
+    <code>msg.template</code>によってテンプレートを定義することもできます。例えば、外部ファイルに格納したテンプレートを用いる場合に有用です。<br>
+    テンプレートは入力が変化した場合に再ロードされます。<br>
+    「HTMLコード」フィールドに記述したコードは、<code>msg.template</code>が存在する場合には無視されます。</p>
+    <p>以下のアイコンフォントの利用も可能です: <a href="https://design.google.com/icons/" target="_blank">Material Design icons</a>,
+    <a href="https://fontawesome.com/v4.7.0/icons/" target="_blank">Font Awesome icons</a>,
+    <a href="https://github.com/Paul-Reed/weather-icons-lite/blob/master/css/weather-icons-lite.css" target="_blank">Weather icons</a></p>
+</script>

--- a/nodes/locales/ja/ui_template.json
+++ b/nodes/locales/ja/ui_template.json
@@ -1,0 +1,16 @@
+{
+    "ui_template" : {
+	"label" : {
+	    "category" : "dashboard",
+	    "type" : "コード種別",
+	    "local" : "グループ内のWidget",
+	    "global" : "<head>ヘッドセクションへ追加",
+	    "group" : "グループ",
+	    "size" : "サイズ",
+	    "name" : "名前",
+	    "pass-through" : "入力メッセージをそのまま渡す",
+	    "store-state" : "出力メッセージを状態として保存",
+	    "template" : "HTMLコード"
+	}
+    }
+}

--- a/nodes/ui_template.html
+++ b/nodes/ui_template.html
@@ -1,6 +1,11 @@
 <script type="text/javascript">
+    // convert to i18 text
+    function c_(x) {
+        return RED._("node-red-dashboard/ui_template:ui_template."+x);
+    }
+
     RED.nodes.registerType('ui_template',{
-        category: 'dashboard',
+        category: c_("label.category"),
         color: 'rgb( 63, 173, 181)',
         defaults: {
             group: {type: 'ui_group', required:false},
@@ -124,40 +129,40 @@
 
 <script type="text/x-red" data-template-name="ui_template">
   <div class="form-row">
-      <label for="node-input-format">Template type</label>
+      <label for="node-input-format"><span data-i18n="ui_template.label.type"></span></label>
       <select style="width:76%" id="node-input-templateScope">
-          <option value="local">Widget in group</option>
-          <option value="global">Added to site &lt;head&gt; section</option>
+          <option value="local" data-i18n="ui_template.label.local"></option>
+          <option value="global" data-i18n="ui_template.label.global"></option>
       </select>
   </div>
 	<div class="form-row" id="template-row-group">
-        <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
+        <label for="node-input-group"><i class="fa fa-table"></i> <span data-i18n="ui_template.label.group"></span></label>
         <input type="text" id="node-input-group">
     </div>
     <div class="form-row" id="template-row-size">
-        <label><i class="fa fa-object-group"></i> Size</label>
+        <label><i class="fa fa-object-group"></i> <span data-i18n="ui_template.label.size"></span></label>
         <input type="hidden" id="node-input-width">
         <input type="hidden" id="node-input-height">
         <button class="editor-button" id="node-input-size"></button>
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="ui_template.label.name"></span></label>
         <input type="text" id="node-input-name">
     </div>
     <div id="template-pass-store">
     <div class="form-row" style="margin-bottom:0px;">
         <label>&nbsp;</label>
         <input type="checkbox" id="node-input-fwdInMessages" style="display:inline-block; width:auto; vertical-align:top;">
-        <label for="node-input-fwdInMessages" style="width:70%;"> Pass through messages from input.</label>
+        <label for="node-input-fwdInMessages" style="width:70%;"> <span data-i18n="ui_template.label.pass-through"></span></label>
     </div>
     <div class="form-row" style="margin-bottom:0px;">
         <label>&nbsp;</label>
         <input type="checkbox" id="node-input-storeOutMessages" style="display:inline-block; width:auto; vertical-align:top;">
-        <label for="node-input-storeOutMessages" style="width:70%;"> Add output messages to stored state.</label>
+        <label for="node-input-storeOutMessages" style="width:70%;"> <span data-i18n="ui_template.label.store-state"></span></label>
     </div>
     </div>
     <div class="form-row" style="margin-bottom:0px;">
-        <label for="node-input-format"><i class="fa fa-copy"></i> Template</label>
+        <label for="node-input-format"><i class="fa fa-copy"></i> <span data-i18n="ui_template.label.template"></span></label>
         <input type="hidden" id="node-input-format">
     </div>
     <div class="form-row node-text-editor-row">

--- a/nodes/ui_template.html
+++ b/nodes/ui_template.html
@@ -176,10 +176,10 @@
     based on the input message and can send back messages to Node-RED.</p>
     <p><b>For example:</b><br>
     <pre style="font-size:smaller;">&lt;div layout=&quot;row&quot; layout-align=&quot;space-between&quot;&gt;
-&lt;p&gt;The number is&lt;/p&gt;
-&lt;p ng-style=&quot;{color: (msg.payload || 0) % 2 === 0 ? 'green' : 'red'}&quot;&gt;
-  {{(msg.payload || 0) % 2 === 0 ? 'even' : 'odd'}}
-&lt;/p&gt;
+  &lt;p&gt;The number is&lt;/p&gt;
+  &lt;p ng-style=&quot;{color: (msg.payload || 0) % 2 === 0 ? 'green' : 'red'}&quot;&gt;
+    {{(msg.payload || 0) % 2 === 0 ? 'even' : 'odd'}}
+  &lt;/p&gt;
 &lt;/div&gt;</pre>
     Will display if the number received as <code>msg.payload</code> is even or odd. It will also
     change the color of the text to green if the number is even or red if odd.<br/>


### PR DESCRIPTION
Current `ui_template` UI widget is not i18n ready.
This PR adds support of i18n and Japanese message catalogue for `ui_template`.
Also fixed indentation of an example in English info text.