### PR TITLE
add support of i18n and JP messages to ui_ui_control node

### DIFF
--- a/nodes/locales/en-US/ui_ui_control.json
+++ b/nodes/locales/en-US/ui_ui_control.json
@@ -1,0 +1,11 @@
+{
+    "ui_ui_control" : {
+	"label" : {
+	    "category" : "dashboard",
+	    "name" : "Name"
+	},
+        "placeholder" : {
+            "name" : "Name"
+        }
+    }
+}

--- a/nodes/locales/ja/ui_ui_control.html
+++ b/nodes/locales/ja/ui_ui_control.html
@@ -1,0 +1,15 @@
+<script type="text/x-red" data-help-name="ui_ui_control">
+    <p>ダッシュボードの動的制御を行います</p>
+    <p>表示されているタブの切り替えが可能です。<code>msg.payload</code>に
+The default function is to change the currently displayed tab. <code>msg.payload</code>に表示対象のタブもしくはリンクの<code>{tab:"タブ名"}</code>、<b>タブ名</b>、もしくは、<b>添字</b> (0起点)を指定します。</p>
+    <p>空のタブ名("")を送信すると、表示されているページを更新します。また、"+1"を送ると次のタブ、"-1"を送ると前のタブに切り替えられます。</p>
+    <p>widgetグループを表示を次のようなペイロードで制御できます。<br/>
+<code>{group:{hide:["タブ名_グループ名"], show:["他_グループ_表示"], focus:true}}</code><br/>
+    <b>focus</b>は、グループが表示されるよう必要に応じて画面をスクロールするためのパラメータで、省略可能です。グループの指定は<i>タブ名</i>と<i>グループ名</i>を下線(_)で結合したものを用います。空白は下線で置き換えます。</p>
+    <p>クライアントのブラウザが接続もしくは切断した場合、次のプロパティを持つメッセージを送信します:</p>
+    <ul>
+    <li><code>payload</code> - <i>connect</i>もしくは<i>lost</i>,
+    <li><code>socketid</code> - ソケットID(ブラウザがページを再ロードする毎に変化します),
+    <li><code>socketip</code> - 接続元のIPアドレス。
+    </ul>
+</script>

--- a/nodes/locales/ja/ui_ui_control.json
+++ b/nodes/locales/ja/ui_ui_control.json
@@ -1,0 +1,11 @@
+{
+    "ui_ui_control" : {
+	"label" : {
+	    "category" : "dashboard",
+	    "name" : "名前"
+	},
+        "placeholder" : {
+            "name" : "名前"
+        }
+    }
+}

--- a/nodes/ui_ui_control.html
+++ b/nodes/ui_ui_control.html
@@ -1,6 +1,11 @@
 <script type="text/javascript">
+    // convert to i18 text
+    function c_(x) {
+        return RED._("node-red-dashboard/ui_ui_control:ui_ui_control."+x);
+    }
+
     RED.nodes.registerType('ui_ui_control', {
-        category: 'dashboard',
+        category: c_("label.category"),
         color: 'rgb( 63, 173, 181)',
         defaults: {
             name: {value:""}
@@ -17,8 +22,8 @@
 
 <script type="text/x-red" data-template-name="ui_ui_control">
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name" placeholder="Name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="ui_ui_control.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]ui_ui_control.placeholder.name">
     </div>
 </script>
 


### PR DESCRIPTION
`ui_ui_control` widget node is not i18n ready.

This PR add support of i18n and corresponding Japanese message catalogue.