### PR TITLE
Fix typo

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -654,7 +654,7 @@
                 var site_name = c_("site.title");
                 var site_date_format = c_("site.date-format");
                 var divDateFormat = $('<div>',{class:"form-row"}).appendTo(siteTab);
-                $('<div">').html('<b>'+c_("label.date-format")+'</b>')
+                $('<div>').html('<b>'+c_("label.date-format")+'</b>')
                 .css("width","80%")
                 .css("display","inline-block")
                 .appendTo(divDateFormat);


### PR DESCRIPTION
Fixed error: Failed to execute 'createElement' on 'Document': The tag name provided ('div"') is not a valid name.