### PR TITLE
ui_audio: reset msg & node status

### DIFF
--- a/nodes/ui_audio.html
+++ b/nodes/ui_audio.html
@@ -75,4 +75,11 @@
     <p>Expects <code>msg.payload</code> to contain a buffer of a <b>wav</b> or <b>mp3</b> file.</p>
     <p>If your browser has native support for Text-to-Speech then a <code>msg.payload</code>
     can also be a <b>string</b> to be read aloud.</p>
+    <p>When a <code>msg.reset</code> is available with value <code>true</code>, then playback of the current audio fragment will be stopped.</p>
+    <p>The <b>node status</b> reflects the current playback status:
+    <ul>
+        <li><b>started:</b> the audio fragment playback has been started.</li>
+        <li><b>reset:</b> the audio fragment playback has been reset (i.e. stopped before completed).</li>
+    </ul>
+    As soon as the audio fragment playback is completed, the node status will be cleared automatically.</p>
 </script>

--- a/nodes/ui_audio.js
+++ b/nodes/ui_audio.js
@@ -10,14 +10,34 @@ module.exports = function(RED) {
             this.tabname = RED.nodes.getNode(RED.nodes.getNode(this.group).config.tab).name;
         }
         var node = this;
+        node.status({});
+
         this.on('input', function(msg) {
-            if (Buffer.isBuffer(msg.payload)) {
+            if (msg.reset == true) {
+                ui.emit('ui-audio', { reset:true, tabname:node.tabname, always:node.always });
+            }
+            else if (Buffer.isBuffer(msg.payload)) {
                 ui.emit('ui-audio', { audio:msg.payload, tabname:node.tabname, always:node.always });
             }
             else if (typeof msg.payload === "string") {
                 ui.emit('ui-audio', { tts:msg.payload, voice:(node.voice || msg.voice || 0), tabname:node.tabname, always:node.always });
             }
         });
+
+        var updateStatus = function(audioStatus) {
+            if (audioStatus === "complete") {
+                // When the audio or speech has played completely, clear the node status
+                node.status({});
+            }
+            else {
+                node.status({shape:"dot",fill:"blue",text:audioStatus});
+            }
+        };
+        ui.ev.on('audiostatus', updateStatus);
+
+        this.on('close', function() {
+            ui.ev.removeListener('audiostatus', updateStatus);
+        })
     }
     RED.nodes.registerType("ui_audio", uiAudioNode);
 }

--- a/ui.js
+++ b/ui.js
@@ -366,6 +366,9 @@ function init(server, app, log, redSettings) {
         socket.on('disconnect', function() {
             ev.emit("endsocket", socket.client.id, socket.request.connection.remoteAddress);
         });
+        socket.on('ui-audio', function(audioStatus) {
+            ev.emit("audiostatus", audioStatus, socket.client.id, socket.request.connection.remoteAddress);
+        });
     });
 }
 


### PR DESCRIPTION
Hi Dave,

As discussed on the [forum](https://discourse.nodered.org/t/node-red-dashboard-audio-wish/4798/26), here is my PR that adds two new functionalities for the **ui_audio** widget:
1. Allow the current playback to be stopped, by sending a ```msg.reset=true```.
1. Show in the node status the current playback status (from the browser side):
   + When the playback is active it shows '_**playing**_'.
   + When the playback is stopped (via ```msg.reset```) it shows '_**reset**_'.
   + When the playback has ended (i.e. audio fragement has entirely played) the node status will be cleared.

I have passed it through **gulp** to make sure the layout is correct.

This flow can be used to test both the playback of normal audio fragments and also TTS fragments:

![image](https://user-images.githubusercontent.com/14224149/48509491-94b9ce00-e851-11e8-9e67-d50e67cf7083.png)

```
[{"id":"ca5d0b4.35f82f8","type":"http request","z":"de796371.b69e4","name":"","method":"GET","ret":"bin","url":"http://soundbible.com/grab.php?id=1917&type=mp3","tls":"","x":550,"y":140,"wires":[["9e5f3e7e.2bcd8"]]},{"id":"edff7452.e4cab8","type":"inject","z":"de796371.b69e4","name":"Start","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":370,"y":140,"wires":[["ca5d0b4.35f82f8"]]},{"id":"9e5f3e7e.2bcd8","type":"ui_audio","z":"de796371.b69e4","name":"","group":"16a1f12d.07c69f","voice":"","always":"","x":799,"y":140,"wires":[]},{"id":"d488f83d.23e358","type":"inject","z":"de796371.b69e4","name":"Stop","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":370,"y":200,"wires":[["9c5866f6.dcf8b8"]]},{"id":"9c5866f6.dcf8b8","type":"change","z":"de796371.b69e4","name":"","rules":[{"t":"set","p":"reset","pt":"msg","to":"true","tot":"bool"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":200,"wires":[["9e5f3e7e.2bcd8"]]},{"id":"edfe6358.377b8","type":"status","z":"de796371.b69e4","name":"","scope":["9e5f3e7e.2bcd8"],"x":360,"y":460,"wires":[["3357ee45.622682"]]},{"id":"3357ee45.622682","type":"debug","z":"de796371.b69e4","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"status.text","x":540,"y":460,"wires":[]},{"id":"5b07fbdf.2d37f4","type":"inject","z":"de796371.b69e4","name":"Start","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":370,"y":320,"wires":[["d26f1afc.b13c98"]]},{"id":"f4a76fb0.4053c","type":"ui_audio","z":"de796371.b69e4","name":"Play TTS","group":"16a1f12d.07c69f","voice":"en-US","always":true,"x":799,"y":320,"wires":[]},{"id":"aa3fae7.25ebd5","type":"inject","z":"de796371.b69e4","name":"Stop","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":370,"y":380,"wires":[["7c95bf0e.15e11"]]},{"id":"7c95bf0e.15e11","type":"change","z":"de796371.b69e4","name":"","rules":[{"t":"set","p":"reset","pt":"msg","to":"true","tot":"bool"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":380,"wires":[["f4a76fb0.4053c"]]},{"id":"d26f1afc.b13c98","type":"change","z":"de796371.b69e4","name":"Set TTS text","rules":[{"t":"set","p":"payload","pt":"msg","to":"This is a long test.  Let's start by getting an image from the internet.  This mp3 file will be send via the audio node, to the dashboard which runs in the browser.  As soon as the browser starts playing the mp3 fragment, a status update will be send back the the flow.  This way the server knows the status of the audio.","tot":"str"}],"action":"","property":"","from":"","to":"","reg":false,"x":550,"y":320,"wires":[["f4a76fb0.4053c"]]},{"id":"990ed3ae.fffde","type":"comment","z":"de796371.b69e4","name":"Test 1 - normal audio fragment","info":"","x":420,"y":100,"wires":[]},{"id":"3451e85c.090748","type":"comment","z":"de796371.b69e4","name":"Test 2 - TTS fragment","info":"","x":400,"y":280,"wires":[]},{"id":"16a1f12d.07c69f","type":"ui_group","z":"","name":"Default","tab":"f136a522.adc2a8","order":1,"disp":true,"width":"6"},{"id":"f136a522.adc2a8","type":"ui_tab","z":"","name":"Home","icon":"home","order":1}]
```

In this test case the remaining **issue** will be visible: when e.g. the audio playback is started, then the status of BOTH audio-out nodes will be updated.  This will be a bit confusing to users, since in this case the TTS fragment is not playing...

It would be nice if we could have a solution for this, before we publish this functionality on NPM.  As soon as users combine this feature with a **Status** node, we could break existing flows if we would change this behaviour afterwards.

P.S. I have considered to add also a '**pause**' and '**resume**' functionality, but then I could run into problems afterwards (for my future PR).  Indeed when you would pause a live audio stream, the (endless) stream would start queuing audio chunks.  At the end we would run out of memory ...

Hope you like it...

Greetings from Belgium,
Bart