### PR TITLE
Allow ui_control through msg.payload.tabs

### DIFF
--- a/nodes/ui_ui_control.html
+++ b/nodes/ui_ui_control.html
@@ -34,8 +34,11 @@
     or <b>numeric index</b> (from 0) of the tab or link to be displayed.</p>
     <p>Sending a blank tab name "" will refresh the current page.
     You can also send "+1" for next tab and "-1" for previous tab.</p>
+    <p>Dashboard pages (i.e. "tabs") can be controlled by sending a <code>msg.payload</code> object with the format
+    <code>{"tabs": {"hide": "tab_name_to_hide", "disable": ["secret_tab", "unused_stuff"]}}</code>.
+    <i>(there are 2 toggle states available: <b>show</b>/<b>hide</b> and <b>enable</b>/<b>disable</b>)</i></p>
     <p>Visibility of individual groups of widgets can controlled by a payload like
-    <code>{"group":{"hide":["tab_name_group_name_with_underscores"], "show":["reveal_another_group"], "focus":true}}</code>
+    <code>{"group": {"hide": ["tab_name_group_name_with_underscores"], "show": ["reveal_another_group"], "focus": true}}</code>
     where <b>focus</b> is optional and will cause the screen to scroll to show that group if required. The group
     names are the IDs of the groups and are typically formed from the <i>tab name</i> plus <i>group name</i> joined with
     underscores replacing all spaces.</p>

--- a/nodes/ui_ui_control.js
+++ b/nodes/ui_ui_control.js
@@ -7,10 +7,15 @@ module.exports = function(RED) {
 
         this.on('input', function(msg) {
             if (typeof msg.payload !== "object") { msg.payload = {tab:msg.payload}; }
+            // show/hide or enable/disable tabs
+            if (msg.payload.hasOwnProperty("tabs")) {
+                ui.emit('ui-control', {tabs:msg.payload.tabs, socketid:msg.socketid});
+            }
             // switch to tab name (or number)
             if (msg.payload.hasOwnProperty("tab")) {
                 ui.emit('ui-control', {tab:msg.payload.tab, socketid:msg.socketid});
             }
+            // show or hide ui groups
             if (msg.payload.hasOwnProperty("group")) {
                 ui.emit('ui-control', {group:msg.payload.group, socketid:msg.socketid});
             }

--- a/src/main.js
+++ b/src/main.js
@@ -89,7 +89,7 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
             var len = main.menu.length;
             if (len > 1) {
                 //var i = parseInt($location.path().substr(1));
-                for (var i = tabId + d; i != tabId; i += d) {
+                for (var i = +tabId + d; i != tabId; i += d) {
                     i = i % len;
                     if (i < 0) { i += len; }
                     if (!main.menu[i].disabled && !main.menu[i].hidden) {
@@ -419,6 +419,14 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
             return elFound;
         }
 
+        function arrayIncludesName(strArray, strName) {
+            // if an array of names is input, use it -- else build an array of one name
+            var arrNames = strArray && Array.isArray(strArray) ? strArray : [strArray];
+            // convert all names to lower-case, and replace any spaces with '_'
+            arrNames = arrNames.map(n => n.toLowerCase().replace(/\s+/, '_'));
+            return arrNames.includes(strName.toLowerCase().replace(/\s+/, '_'));
+        }
+
         events.on(function (msg) {
             var found;
             if (msg.hasOwnProperty('msg') && msg.msg.templateScope === 'global') {
@@ -517,7 +525,36 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
                 }
                 //Object.assign(found,msg.control);
             }
+            if (msg.hasOwnProperty("tabs")) { // ui_control request to show/hide/enable/disable tabs
+                if (typeof msg.tabs === 'object') {
+                    for (var t in main.menu) {
+                        if (main.menu.hasOwnProperty(t)) {
+                            if (msg.tabs.hasOwnProperty("show")) {
+                                if (arrayIncludesName(msg.tabs.show, main.menu[t].header)) {
+                                    main.menu[t].hidden = false;
+                                }
+                            }
+                            if (msg.tabs.hasOwnProperty("hide")) {
+                                if (arrayIncludesName(msg.tabs.hide, main.menu[t].header)) {
+                                    main.menu[t].hidden = true;
+                                }
+                            }
+                            if (msg.tabs.hasOwnProperty("enable")) {
+                                if (arrayIncludesName(msg.tabs.enable, main.menu[t].header)) {
+                                    main.menu[t].disabled = false;
+                                }
+                            }
+                            if (msg.tabs.hasOwnProperty("disable")) {
+                                if (arrayIncludesName(msg.tabs.disable, main.menu[t].header)) {
+                                    main.menu[t].disabled = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             if (msg.hasOwnProperty("tab")) { // if it's a request to change tabs
+                // is it a tab name or relative number?
                 if (typeof msg.tab === 'string') {
                     if (msg.tab === "") { events.emit('ui-refresh', {}); }
                     if (msg.tab === "+1") { moveTab(1); return; }


### PR DESCRIPTION
Dashboard tabs can be shown/hidden and enabled/disabled by sending
control options. Changes take effect immediately within the browser, but
are not yet persisted at the server.