### PR TITLE
fix dashboard disconnection in Firefox when the tab is in background

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -491,6 +491,7 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
                     found.me.processInput(msg);
                 }
             }
+            $scope.$apply();
         });
 
         events.on('disconnect', function(m) {

--- a/src/services/events.js
+++ b/src/services/events.js
@@ -22,7 +22,7 @@ angular.module('ui').service('UiEvents', ['$timeout',
                 }
 
                 var socketHandler = function(data) {
-                    $timeout(function() { handler(data); }, 0);
+                    handler(data);
                 };
 
                 socket.on(event, socketHandler);


### PR DESCRIPTION
fix dashboard disconnection in Firefox when the tab is in background