### PR TITLE
fix NPE when migrating from legacy contrib-ui

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -204,7 +204,7 @@ function add(opt) {
             else { toEmit = toStore; }
 
             var addField = function(m) {
-                if (opt.control.hasOwnProperty(m) && opt.control[m].indexOf("{{") !== -1) {
+                if (opt.control.hasOwnProperty(m) && opt.control[m] && opt.control[m].indexOf("{{") !== -1) {
                     var a = opt.control[m].split("{{");
                     a.shift();
                     for (var i = 0; i < a.length; i++) {


### PR DESCRIPTION
```Αυγ 02 06:56:42 pi-stretch Node-RED[3280]: 2 Aug 06:56:42 - [red] Uncaught Exception:
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]: 2 Aug 06:56:42 - TypeError: Cannot read property 'indexOf' of undefined
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at addField (/home/pi/.node-red/node_modules/node-red-dashboard/ui.js:207:69)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at ChartNode.<anonymous> (/home/pi/.node-red/node_modules/node-red-dashboard/ui.js:240:13)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at ChartNode.emit (events.js:198:13)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at Timeout._onTimeout (/home/pi/.node-red/node_modules/node-red-dashboard/nodes/ui_chart.js:268:18)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at ontimeout (timers.js:436:11)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at tryOnTimeout (timers.js:300:5)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at listOnTimeout (timers.js:263:5)
Αυγ 02 06:56:42 pi-stretch Node-RED[3280]:     at Timer.processTimers (timers.js:223:10)
Αυγ 02 06:56:43 pi-stretch systemd[1]: nodered.service: Main process exited, code=exited, status=1/FAILURE
Αυγ 02 06:56:43 pi-stretch systemd[1]: nodered.service: Failed with result 'exit-code'.
Αυγ 02 06:56:43 pi-stretch systemd[1]: nodered.service: Service RestartSec=100ms expired, scheduling restart.
```