### PR TITLE
fix to prevent node(s) from creating null msg.topic

### DIFF
--- a/nodes/ui_button.js
+++ b/nodes/ui_button.js
@@ -51,7 +51,7 @@ module.exports = function(RED) {
                 height: config.height || 1
             },
             beforeSend: function (msg) {
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
             },
             convertBack: function (value) {
                 if (payloadType === "date") {

--- a/nodes/ui_colour_picker.js
+++ b/nodes/ui_colour_picker.js
@@ -43,7 +43,7 @@ module.exports = function(RED) {
                     if (node.format === 'hsl') { msg.payload = pay.toHsl(); }
                     if (node.format === 'hsv') { msg.payload = pay.toHsv(); }
                 }
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
             },
             convert: function(p,o,m) {
                 if (m.payload === undefined) { return; }

--- a/nodes/ui_date_picker.js
+++ b/nodes/ui_date_picker.js
@@ -38,7 +38,7 @@ module.exports = function(RED) {
                 return d;
             },
             beforeSend: function (msg) {
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
             }
         });
         node.on("close", done);

--- a/nodes/ui_dropdown.js
+++ b/nodes/ui_dropdown.js
@@ -124,7 +124,7 @@ module.exports = function(RED) {
                     delete msg.options;
                     msg.payload = emitOptions.value;
                 }
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
                 if (node.pt) {
                     node.status({shape:"dot",fill:"grey",text:msg.payload});
                 }

--- a/nodes/ui_numeric.js
+++ b/nodes/ui_numeric.js
@@ -36,7 +36,7 @@ module.exports = function(RED) {
             },
             beforeSend: function (msg) {
                 msg.payload = parseFloat(msg.payload);
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
                 if (node.pt) {
                     node.status({shape:"dot",fill:"grey",text:msg.payload});
                 }

--- a/nodes/ui_slider.js
+++ b/nodes/ui_slider.js
@@ -33,7 +33,7 @@ module.exports = function(RED) {
                 height: config.height || 1
             },
             beforeSend: function (msg) {
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
                 if (node.pt) {
                     node.status({shape:"dot",fill:"grey",text:msg.payload});
                 }

--- a/nodes/ui_switch.js
+++ b/nodes/ui_switch.js
@@ -120,7 +120,7 @@ module.exports = function(RED) {
                 return value;
             },
             beforeSend: function (msg) {
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
             }
         });
 

--- a/nodes/ui_text_input.js
+++ b/nodes/ui_text_input.js
@@ -34,7 +34,7 @@ module.exports = function(RED) {
                 }
                 // if (config.mode === "week") { msg.payload = Date.parse(msg.payload); }
                 // if (config.mode === "month") { msg.payload = Date.parse(msg.payload); }
-                msg.topic = config.topic || msg.topic;
+                msg.topic = config.topic || msg.topic || "";
             }
         });
         node.on("close", done);


### PR DESCRIPTION
Several of the UI nodes have the following line of code:
` msg.topic = config.topic || msg.topic;`
However if config.topic is empty AND msg.topic is empty, then neither case is TRUE so msg.topic is not set. This can be corrected by changing that line to:
`msg.topic = config.topic || msg.topic || "";`
and if neithor config.topic or msg.topic exist an empty msg.topic will be build in the outgoing msg.

The following have the issue and have been changed:
ui_button.js - line: 54
ui_colour_picker.js - line: 46
ui_date_picker.js - line: 41
ui_dropdown.js - line: 127
ui_numeric.js - line: 39
ui_slider.js - line: 36
ui_switch.js - line: 123
ui_text_input.js - line: 37


