### PR TITLE
fix chart height if title is empty (retry) 

### DIFF
--- a/src/components/ui-component/templates/chart.css
+++ b/src/components/ui-component/templates/chart.css
@@ -34,3 +34,7 @@ canvas.chart.chart-line {
     width: calc(100% - 10px);
     padding: 5px;
 }
+.nr-dashboard-chart-nolabel {
+    /* full height - label_padding - nr-dashboard-chart_padding */
+    height: calc(100% - 40px);
+}

--- a/src/components/ui-component/templates/chart.html
+++ b/src/components/ui-component/templates/chart.html
@@ -7,6 +7,7 @@
         </p>
         <ui-chart-js
             class="nr-dashboard-chart"
+            ng-class="{'nr-dashboard-chart-nolabel':me.item.getLabel() == ''}"
             ng-swipe-right="$event.stopPropagation();"
             ng-swipe-left="$event.stopPropagation();"
             >


### PR DESCRIPTION
Issue mentioned here https://discourse.nodered.org/t/chart-node-wasted-space/17562
Chart without the optional label waisted space
![image](https://user-images.githubusercontent.com/35291460/68273874-490ac080-0070-11ea-9987-5a998a1481ef.png)

By adding ng-class in case the chart label is empty, chart can use available space as much as with label presented.

![image](https://user-images.githubusercontent.com/35291460/68273938-72c3e780-0070-11ea-9c36-15fc5fd63f47.png)
