### PR TITLE
Added crossorigin attribute to manifest link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
     <meta name="apple-mobile-web-app-title" content="Node-RED">
     <meta name="mobile-web-app-capable" content="yes">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="manifest" href="manifest.json">
+    <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
     <link rel="icon" sizes="192x192" href="icon192x192.png">
     <link rel="shortcut icon" type="image/png" href="icon64x64.png">
     <link rel="apple-touch-icon" href="icon120x120.png">


### PR DESCRIPTION
I have NodeRED UI and Dashboard setup with HTTP Basic authentication. From Android-Chrome I noticed that when I open Dashboard, authenticate, then after day or so, when I open Dashboard, I can see that it loads something, but shows blank gray screen - no header, menu, groups, widgets.... nothing. With Chromes dev tools I can see that index.html and all resourses are loaded from memory (web app), but `manifest.json` file gets HTTP 401 and browser does not ask to authenticate.

As I have HTTP authentication enabled, then loading manifest file is restricted as it's considered as cross-origin request:

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
> The use-credentials value must be used when fetching a manifest that requires credentials, even if the file is from the same origin.

This PR adds `crossorigin="use-credentials"` attribute to manifest link.