### PR TITLE
fix to make order of ui_group node defined

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -2259,6 +2259,11 @@
                                         RED.nodes.updateConfigNodeUsers(group.node);
                                     }
                                 }
+                                else {
+                                    if (group.node.order === undefined) {
+                                        group.node.order = i+1;
+                                    }
+                                }
                                 var groupNode = group.node;
                                 elementParents[groupNode] = item.node.id;
                                 var titleRow = $('<div>',{class:"nr-db-sb-list-header nr-db-sb-group-list-header"}).appendTo(container);


### PR DESCRIPTION
Adding a `ui_group` from group item of widget's settings menu makes `order` property of the `ui_group` undefined.
In some cases, this makes groups layout in dashboard unsynchronized with layout list in sidebar.

This PR try to fix this problem.

![スクリーンショット 2020-04-12 11 49 30](https://user-images.githubusercontent.com/30289092/79059346-d3a4bb00-7cb3-11ea-9e83-958d61861c3e.png)
