### PR TITLE
make grid option not reused

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -2073,17 +2073,6 @@
                                     trayBody.append(editor);
 
                                     /////////////////////////////////////////
-                                    // Gridstack.js option
-                                    ////////////////////////////////////////
-                                    var options = {
-                                        cellHeight: 46,
-                                        verticalMargin: 1,
-                                        float: true,
-                                        alwaysShowResizeHandle: true,
-                                        disableOneColumnMode : true
-                                    };
-
-                                    /////////////////////////////////////////
                                     // Editor screen generation
                                     /////////////////////////////////////////
                                     oldSpacer = [];
@@ -2092,6 +2081,14 @@
                                     widgetResize = [];
                                     widgetDrag = [];
                                     for (var cnt=0; cnt < groups.length; cnt++) {
+                                        // Gridstack.js option
+                                        var options = {
+                                            cellHeight: 46,
+                                            verticalMargin: 1,
+                                            float: true,
+                                            alwaysShowResizeHandle: true,
+                                            disableOneColumnMode : true
+                                        };
                                         var gridID='#grid' + cnt;
                                         // gridstack generation
                                         $(gridID).gridstack(options);


### PR DESCRIPTION
This issue (https://github.com/node-red/node-red-dashboard/issues/577) seems to be caused by  reuse of a option object for grid creation API of GridStack.  GridStack skips column size setting if column option is already set.
This PR attempts to fix the problem.