### PR TITLE
Force page reload if socket.io gets 401 response code

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -512,6 +512,39 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
             }
         });
 
+        events.on('connect_error', function (error) {
+            var getRandomFromUrl = function () {
+                var matches = window.location.search.match(/[?&]random=([^&]*)/);
+                return (matches && matches[1] || 0) * 1;
+            };
+            var forceReload = function () {
+                // avoid reload loop
+                if ((new Date()).getTime() - getRandomFromUrl() < 60000) {
+                    return;
+                }
+
+                // remove existing 'random' and add new one
+                var search = window.location.search;
+                search = search.replace(/[?&]random=([^&]*)/, '');
+                if (!search.startsWith('?')) {
+                    search = '?' + search;
+                }
+                search += '&random=' + (new Date()).getTime();
+
+                // restore new url with updated search params
+                var url = window.location.origin;
+                url += window.location.pathname;
+                url += search;
+                url += window.location.hash;
+                window.location = url;
+            };
+
+            // force reload on Unauthorized response
+            if (error.type === 'TransportError' && error.description === 401) {
+                forceReload();
+            }
+        });
+
         events.on('show-toast', function (msg) {
             if (msg.raw !== true) {
                 var temp = document.createElement('div');


### PR DESCRIPTION
Using NodeRed + Dashboard behind Basic auth proxy and Android-Chrome.

Android-Chrome will forget credentials after some days. From chrome dev tools I can see that all resources are loaded from memory, but `socket.io` connection fails with http code 401, retries every 5 seconds and browser does not ask to re-authenticate. Same behavior happens if user password is changed, so no need to wait few days to test this behavior.

Looked at `socket.io` documentation and could not find anything that would trigger re-authentication. Only way that worked was to reload page with unique url. For that added new query parameter `random` with current timestamp when `socket.io` connection fails with 401 code.

I have never used `angular` so I do not know if there is easier way to reload page with updated query parameters, so did it Vanilla JS way.

Related PR #560