### PR TITLE
Fix history navigation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -157,10 +157,7 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
                     if (typeof main.menu[index].link === "string") {
                         main.menu[index].link = $sce.trustAsResourceUrl(main.menu[index].link);
                     }
-                    main.selectedTab = main.menu[index];
-                    tabId = index;
-                    events.emit('ui-change', tabId);
-                    $location.path(index);
+                    main.select(index);
                 }
                 $mdSidenav('left').close();
             }

--- a/src/main.js
+++ b/src/main.js
@@ -112,6 +112,19 @@ app.controller('MainController', ['$mdSidenav', '$window', 'UiEvents', '$locatio
         $scope.onSwipeLeft = function() { if (main.allowSwipe) { moveTab(-1); } }
         $scope.onSwipeRight = function() { if (main.allowSwipe) { moveTab(1); } }
 
+        $scope.$on('$locationChangeSuccess', function ($event, newUrl, oldUrl, newState, oldState) {
+            if ($location.path() === '/' + tabId) {
+                return;
+            }
+            var tabIdFromUrlPath = parseInt($location.path().split('/')[1], 10);
+            if (!isNaN(tabIdFromUrlPath)) {
+                var menu = main.menu[tabIdFromUrlPath];
+                if (menu) {
+                    main.open(menu, tabIdFromUrlPath);
+                }
+            }
+        });
+
         $rootScope.$on("collapse", function(e,d,d2) {
             events.emit('ui-collapse', {group:d, state:d2});
         });


### PR DESCRIPTION
On dashboard, when changing tabs and then navigating back or forward in history, then url path changes, but content of dashboard is not. And if reloading page, then appropriate content is loaded based on url path. When left sidenav is open and then navigating back and forward, then active tab changes, but not a content of dashboard.

Checked how this active tab indicator in left menu is done. In menu tab selection element, I can see `ng-class="{'nr-menu-item-active':location.$$path=='/'+$index}"`. Based on this and [this](https://github.com/node-red/node-red-dashboard/blob/7d47e9db254e9299a9b5ab9d2a74f0257cdc025b/src/main.js#L126), I can assume tab index can be extracted from url path. But I am not really sure if this is always so and if it's the best way to do it.

To fix navigation back and forward in history, I added `$locationChangeSuccess` event listener that gets triggered when navigating back/forward. There I extracted tab id from url path and if needed, load appropriate tab content same way as was done in sidenav menu item click.

This is first time I have done anything in Angular. CR and comments are appreciated.