### PR TITLE
Fix default beforeEmit function

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -91,7 +91,7 @@ function noConvert(value) {
 }
 
 function beforeEmit(msg, value) {
-    return { value:value };
+    return { msg: msg };
 }
 
 function beforeSend(msg) {


### PR DESCRIPTION
Hello,
This looks like a typo: the default `beforeEmit()` function seems wrong and results in the message not being delivered to the UI.

Indeed, it looks like the returned value is expected to contain a `msg` property (not a `value` property):
https://github.com/node-red/node-red-dashboard/blob/8326012e5263af3fdf8325b019037622baa48914/ui.js#L228

With this fix, a `$scope.$watch('msg', function (msg) { ... }` works out of the box. Without it, UI widgets have to override the `beforeEmit()` function even when they do not need this event and do not need to make any change to the payload.

Let me know if you need additional information.