### PR TITLE
Update text-input-CR.html

### DIFF
--- a/src/components/ui-component/templates/text-input-CR.html
+++ b/src/components/ui-component/templates/text-input-CR.html
@@ -24,6 +24,7 @@
             ng-trim="false"
             aria-label="{{me.item.label}}"
             type="{{me.item.mode}}"
-            style="z-index:1"/>
+            style="z-index:1"
+            step="any"/>
     </md-input-container>
 </md-card>


### PR DESCRIPTION
Added step="any" attribute to text-input-CR.html. This solves undesired formatting of any floatingpoint number entered in the text field when set to type=number and delay=0.

I've noticed that when using the ui_text_input node (mode = number and delay = 0) floating point numbers are shown as red numbers. Adding the attribute step="any" fixes this behavior.
When delay is set to something else than 0 text-input.html is used instead which also contains this attribute to take care of the formatting issue.
Cheers