### PR TITLE
fix order of copied widget in group list

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -2997,6 +2997,7 @@
                         }
                         return 0
                     });
+                    var updateList = {};
                     for (var i=0; i<pendingAdd.length; i++) {
                         var node = pendingAdd[i];
                         if (node.type === "ui_tab") {
@@ -3023,6 +3024,9 @@
                                 }
                                 if (groupLists[node.group]) {
                                     groupLists[node.group].editableList('addItem',node)
+                                    if (node.order >= 0) {
+                                        updateList[node.group] = true;
+                                    }
                                 }
                                 else {
                                     refreshOrphanedWidgets();
@@ -3030,6 +3034,12 @@
                             }
                         }
                     }
+                    Object.keys(updateList).forEach(function (group) {
+                        var list = groupLists[group];
+                        if (list) {
+                            list.editableList("sort", function(a,b){return a.order-b.order;});
+                        }
+                    });
                     pendingAdd = [];
                 }
 


### PR DESCRIPTION
Copying a widget node will add it to the end of the group's widget list in sidebar.

![スクリーンショット 2020-10-21 22 01 47](https://user-images.githubusercontent.com/30289092/96723832-0b6e8700-13ea-11eb-8fa0-e54a17851e4b.png)

However, in reality, the order property of the original node is inherited, and the layout on the dashboard is in a different order.

![スクリーンショット 2020-10-21 22 02 31](https://user-images.githubusercontent.com/30289092/96723864-145f5880-13ea-11eb-968a-b512db593c6e.png)

This fix attempts to solve the problem by sorting the widget list after node addition.

When copying a node, multiple widget nodes have the same order property value. It may be better to have an automatic renumbering feature.
