### PR TITLE
Add legend option to polar-area and radar chart

### DIFF
--- a/nodes/ui_chart.html
+++ b/nodes/ui_chart.html
@@ -101,6 +101,16 @@
                         $("#legend-show").show();
                         $("#hole-size-show").show();
                     }
+                    else if ($(this).val() === "polar-area") {
+                        $("#y-axis-show").show();
+                        $("#legend-show").show();
+                        $("#hole-size-show").hide();
+                    }
+                    else if ($(this).val() === "radar") {
+                        $("#y-axis-show").show();
+                        $("#legend-show").show();
+                        $("#hole-size-show").hide();
+                    }
                     else {
                         $("#y-axis-show").show();
                         $("#hole-size-show").hide();


### PR DESCRIPTION
Polar-area chart and radar chart do not have legend show/none setting.
(But can be enabled/disabled by changing chart type to other type, set legend option, then changing chart type to polar-area/radar.)
This PR adds legend option to polar-area/radar chart.