### PR TITLE
Fix legend callback error for pie/polar-area chart

### DIFF
--- a/src/components/ui-chart-js/ui-chart-js.js
+++ b/src/components/ui-chart-js/ui-chart-js.js
@@ -364,6 +364,9 @@ function loadConfiguration(type,scope) {
             position:'top',
             labels: { boxWidth:10, fontSize:12, padding:8 },
             onClick: function(e, legendItem) {
+                if ((type === "pie") || (type === "polar-area")) {
+                    return;
+                }
                 var index = legendItem.datasetIndex;
                 var ci = this.chart;
                 var meta = ci.getDatasetMeta(index);


### PR DESCRIPTION
Clicking a legend for polar-area/pie chart causes following error:
```
app.min.js:552 Uncaught TypeError: Cannot read property '_meta' of undefined
    at t.Controller.getDatasetMeta (app.min.js:552)
    at a.onClick (app.min.js:604)
    at a.handleEvent (app.min.js:552)
    at t.Controller.eventHandler (app.min.js:552)
    at t.Controller.<anonymous> (app.min.js:552)
    at HTMLCanvasElement.i.<computed> (app.min.js:552)
```

This problem seems to be caused by the legend processing targeting series, while the legend of polar-area/pie chart is label.  
This PR try to fix this problem by making legend click for these chart types no-op.
