### PR TITLE
Fix tooltip of pie/polar-area chart

### DIFF
--- a/src/components/ui-chart-js/ui-chart-js.js
+++ b/src/components/ui-chart-js/ui-chart-js.js
@@ -381,6 +381,25 @@ function loadConfiguration(type,scope) {
         }
     }
 
+    // Configure custum tooltip
+    if ((type === "pie") || (type === "polar-area")) {
+        // show series instead of labels
+        config.options.tooltips = {
+            callbacks: {
+                label: function(item, data) {
+                    var ds = data.datasets[item.datasetIndex];
+                    var label = ds.label || "";
+                    if (label) {
+                        label += ": ";
+                    }
+                    label += ds.data[item.index];
+                    return label;
+                }
+            }
+        };
+    }
+
+
     // Allow override of any options if really required.
     config.options = Object.assign({},config.options,item.options);
     return config;


### PR DESCRIPTION
Tolptip for pie/polar-area chart  shows the same prefix for multi-dataset as shown in the following figure.

![スクリーンショット 2020-12-27 23 52 19](https://user-images.githubusercontent.com/30289092/103173562-2ef8f680-489f-11eb-9cd7-ff06170ae031.png)

This does not help identifying the data, so this fix uses series name as the prefix.

![スクリーンショット 2020-12-28 0 00 44](https://user-images.githubusercontent.com/30289092/103173668-c3635900-489f-11eb-990c-e740d5323897.png)