### PR TITLE
fix for #684 red crash on empty dropdown node

### DIFF
--- a/nodes/ui_dropdown.js
+++ b/nodes/ui_dropdown.js
@@ -31,7 +31,7 @@ module.exports = function(RED) {
         }
         control.options = config.options;
 
-        var emitOptions;
+        var emitOptions = { value:undefined };
 
         node.on("input", function(msg) {
             node.topi = msg.topic;


### PR DESCRIPTION
emitOptions.value never has the opportunity to be populated when left blank