### PR TITLE
Update ui.js

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -286,6 +286,9 @@ function add(opt) {
 
         if (toSend !== undefined) {
             toSend.socketid = toSend.socketid || msg.socketid;
+            if(msg.hasOwnProperty("meta")) {
+                toSend.meta = msg.meta;
+            }
             if (toSend.hasOwnProperty("topic") && (toSend.topic === undefined)) { delete toSend.topic; }
             // send to following nodes
             if (!msg.hasOwnProperty("_dontSend")) { opt.node.send(toSend); }


### PR DESCRIPTION
copy the meta field from the original message if it exists.

I'd like use be able to annotate messages as they come in and bind them to a "user" using a socket.io middleware. This way, I can do the lookup once on establishing the connection and do a socket.use() handler to add that field to each update-value that comes back from the UI. 

Right now, each node gets to do its own munging of the received message and there's no way (that I can figure) to easily inject this info in the socket middleware. While I could, in theory, do the lookup later using the socketid, I'd have to maintain some table somewhere that maps socketids to users. That seems like a recipe for leaks, whereas this way it's just done in the closure in the handler which should get cleaned up when the socket is released. 
