### PR TITLE
fix unexpected line break of widget size input popup

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -3061,7 +3061,7 @@
             width = (width > 0) ? width : 1;
             height = (height > 0) ? height : 1;
             var in0 = $('<input type="number" min="1" '+max_w+'>')
-                .css("width", has_height ? "45%" : "100%")
+                .css("width", has_height ? "40%" : "100%")
                 .val(width)
                 .appendTo(box0);
             if(has_height) {
@@ -3069,7 +3069,7 @@
                     .text(" x ")
                     .appendTo(box0);
                 var in1 = $('<input type="number" min="1">')
-                    .css("width", "45%")
+                    .css("width", "40%")
                     .val(height)
                     .appendTo(box0);
             }


### PR DESCRIPTION
With current Node-RED dashboard(2.29.3), popup UI for setting widget size is shown in two line as follows.

![スクリーンショット 2021-06-13 23 38 36](https://user-images.githubusercontent.com/30289092/121811811-839efb00-cca0-11eb-9233-f5a4336e4e8d.png)

This PR try to make it shown in single line as shown below.

![スクリーンショット 2021-06-13 23 44 59](https://user-images.githubusercontent.com/30289092/121812065-76ced700-cca1-11eb-8351-9c7f0683fba4.png)
