### PR TITLE
Update ui_text_input.html to initilize className

### DIFF
--- a/nodes/ui_text_input.html
+++ b/nodes/ui_text_input.html
@@ -23,6 +23,7 @@
             delay: {value: 300, validate: RED.validators.number()},
             topic: {value: 'topic', validate: (RED.validators.hasOwnProperty('typedInput')?RED.validators.typedInput('topicType'):function(v) { return true})},
             sendOnBlur: {value: true},
+	    className: {value: ''},
             topicType: {value: 'msg'}
         },
         inputs:1,


### PR DESCRIPTION
Added missing:
className: {value: ''},
to the 'defaults: ' object - this goes with a change to ui_text_input.js