### PR TITLE
fix duplicate tabs in layout list after refresh

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -2954,6 +2954,9 @@
                     var updateList = {};
                     for (var i=0; i<pendingAdd.length; i++) {
                         var node = pendingAdd[i];
+                        if (listElements[node.id]) {
+                            continue;
+                        }
                         if (node.type === "ui_tab") {
                             tabContainer.editableList('addItem',{node:node,groups:[]});
                         }


### PR DESCRIPTION
With new Node-RED 2.2, tabs in layout list may be duplicated after browser refresh.

- steps to reproduce:
    1. open dashboard tab,
    2. refresh screen.
 
![スクリーンショット 2022-01-29 0 09 15](https://user-images.githubusercontent.com/30289092/151571163-e2349bcd-0b2d-4a0f-ae7b-0bf44c776d87.png)

This is thought to be due to the fact that Node-RED 2.2 now retains sidebar tab before screen refreshing.
This fix attempts to avoid duplicate tab additions when refreshing.