### PR TITLE
fix to perform node validation after node addition

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -514,6 +514,7 @@
                             label: function() { return this.name + " " + this.width + "x" + this.height; }
                         };
                         RED.nodes.add(spaceNode);
+                        RED.editor.validateNode(spaceNode);
                         RED.nodes.dirty(true);
                         RED.view.redraw(true);
                     }
@@ -1130,6 +1131,7 @@
                                     users: []
                                 }
                                 RED.nodes.add(globalDashboardNode);
+                                RED.editor.validateNode(globalDashboardNode);
                             }
                             else {
                                 globalDashboardNode["_def"] = RED.nodes.getType("ui_base");
@@ -1857,6 +1859,7 @@
                             item.groups = [];
                         }
                         RED.nodes.add(item.node);
+                        RED.editor.validateNode(item.node);
                         RED.history.push({
                             t:'add',
                             nodes:[item.node.id],
@@ -2179,6 +2182,7 @@
                                     };
                                     listElements[group.node.id] = container;
                                     RED.nodes.add(group.node);
+                                    RED.editor.validateNode(group.node);
                                     group.widgets = [];
                                     RED.history.push({
                                         t:'add',
@@ -2467,6 +2471,7 @@
                             icon: "dashboard"
                         };
                         RED.nodes.add(tab);
+                        RED.editor.validateNode(tab);
                         hev.push(tab.id);
                     }
                     for (var groupId in unknownGroups) {


### PR DESCRIPTION
As reported in [this issue](https://github.com/node-red/node-red/issues/3398), some configuration nodes causes "not properly configured" warning when deploying a flow with Node-RED 2.2.
This is because the configuration node's check introduced in Node-RED 2.2 has revealed a potential dashboard issue that validation is not applied to these configuration nodes.

[This](https://github.com/node-red/node-red/pull/3397) is intended for fixing the Node-RED Editor for compatibility, but this PR fixes the original problem in the Node-RED dashboard.