### PR TITLE
Changed 'Angular filters' link since old linked to site has been take…

### DIFF
--- a/nodes/locales/en-US/ui_gauge.html
+++ b/nodes/locales/en-US/ui_gauge.html
@@ -2,7 +2,7 @@
     <p>Adds a gauge type widget to the user interface.</p>
     <p>The <code>msg.payload</code> is searched for a numeric <i>value</i> and is formatted in accordance with
     the defined <b>Value Format</b>, which can then be formatted using
-    <a href="https://scotch.io/tutorials/all-about-the-built-in-angularjs-filters" target="_blank">Angular filters</a>.</p>
+    <a href="https://docs.angularjs.org/api/ng/filter" target="_blank">Angular filters</a>.</p>
     <p>For example : <code>{{value | number:1}}%</code> will round the value to one decimal place and append a % sign.</p>
     <p>The colours of each of 3 sectors can be specified and the gauge will blend between them.
     The colours should be specified in hex (#rrggbb) format.</p>


### PR DESCRIPTION
…n down

In the Help for the ui-gauge node, the current link on the text 'Angular filters' now takes you to https://www.digitalocean.com/community. The domain it pointed to 'https://scotch.io' redirects to the digital ocean site.

This changes the 'Angular filters' link to point to 'https://docs.angularjs.org/api/ng/filter'