### PR TITLE
Hide scrollbars until they're needed

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -11,7 +11,7 @@
         bottom: 2px;
         left: 1px;
         right: 1px;
-        overflow-y: scroll;
+        overflow-y: auto;
         padding: 10px;
     }
     .nr-db-sb .form-row label {


### PR DESCRIPTION
Shows the scrollbar on the sidebar only when the content overflows.