### PR TITLE
respect document.location.pathname in "Show Dashboard" button to work properly behind reverse proxies

### DIFF
--- a/nodes/ui_base.html
+++ b/nodes/ui_base.html
@@ -1164,7 +1164,7 @@
                 // Link out to dashboard
                 $.getJSON('uisettings',function(data) {
                     if (data.hasOwnProperty("path")) { uip = data.path; }
-                    var lnk = document.location.host+RED.settings.httpNodeRoot+"/"+uip;
+                    var lnk = document.location.host+document.location.pathname+RED.settings.httpNodeRoot+"/"+uip;
                     var re = new RegExp('\/{1,}','g');
                     lnk = lnk.replace(re,'/');
                     if (!RED.hasOwnProperty("actions")) {


### PR DESCRIPTION
Hi,
I'm running Node-RED in a docker container and behind a reverse proxy that I have very limited control over. This reverse proxy creates a route from http://DeviceIP/lorem/ipsum/red to http://127.0.0.1:1880/red.

I noticed that the "Go to Dashboard" Button in the Node-RED Editor points to http://DeviceIP/red/ui, and not http://DeviceIP/lorem/ipsum/red/ui

By changing the settings.js to `//ui: { path: "lorem/ipsum/red/ui" },` I can make the button point to the correct url, however this will also result in the dashboard now being served at http://DeviceIP/lorem/ipsum/lorem/ipsum/red (as expected).

The issue boils down to [node-red-dashboard/ui_base.html](https://github.com/node-red/node-red-dashboard/blob/69bccb57c8131693075c39c360515f3953fa1b90/nodes/ui_base.html#L1167) not including the DOM property `document.location.pathname`, in this case lorem/ipsum.
By changing it to `var lnk = document.location.host+document.location.pathname+RED.settings.httpNodeRoot+"/"+uip;`, the button now points to the correct url, including the pathname set by the reverse proxy.


I've posted this in the Node-RED forum, too: https://discourse.nodered.org/t/node-red-dashboards-go-to-dashboard-button-in-editor-does-not-respect-document-location-pathname/69246