### PR TITLE
Added possibility to "ui_dropdown" component to delete user text in search box

### DIFF
--- a/nodes/locales/en-US/ui_dropdown.html
+++ b/nodes/locales/en-US/ui_dropdown.html
@@ -5,6 +5,7 @@
     <p>The configured value of the selected item will be returned as <code>msg.payload</code>.</p>
     <p>Setting <code>msg.payload</code> to one of the item values will preset the choice in the dropdown.
     If using the multi-select option then the payload should be an array of values.</p>
+    <p>Optionally user search term can deleted if set the <code>msg.resetSearch</code> property is present and true.</p>
     <p>Optionally the <b>Topic</b> field can be used to set the <code>msg.topic</code> property.</p>
     <p>The Options may be configured by inputting <code>msg.options</code> containing an array.
     If just text then the value will be the same as the label, otherwise you can specify both by

--- a/nodes/ui_dropdown.js
+++ b/nodes/ui_dropdown.js
@@ -111,7 +111,9 @@ module.exports = function(RED) {
                         node.error("ERR: Invalid Options", msg);
                     }
                 }
-
+                if (msg.hasOwnProperty("resetSearch") && msg.resetSearch) {
+                    emitOptions.resetSearch = true;
+                }
                 if (msg.hasOwnProperty("payload")) {
                     if (node.multiple) {
                         if (typeof msg.payload === "string") {

--- a/src/components/ui-component/ui-component-ctrl.js
+++ b/src/components/ui-component/ui-component-ctrl.js
@@ -435,6 +435,10 @@ angular.module('ui').controller('uiComponentController', ['$scope', 'UiEvents', 
 
             // may add additional input processing for other controls
             var processDropDownInput = function (msg) {
+                // If resetSearch is present, clear user searchTerm input
+                if (msg && msg.resetSearch) {
+                    me.searchTerm = "";
+                }                
                 // options should have the correct format see beforeEmit in ui-dropdown.js
                 if (msg && msg.isOptionsValid) {
                     me.item.options = msg.newOptions;


### PR DESCRIPTION
Added possibility to "ui_dropdown" component to delete user text in search box on front-end by sending msg.resetSearch = true value. It doesn't affect other existing properties (msg.options or msg.payload)